### PR TITLE
Release account management

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,6 +27,9 @@ const elements = {
   transactionsMenuButton: document.querySelector("#transactions-menu-button"),
   importView: document.querySelector("#import-view"),
   transactionsView: document.querySelector("#transactions-view"),
+  refreshAccounts: document.querySelector("#refresh-accounts"),
+  accountsList: document.querySelector("#accounts-list"),
+  accountsMessage: document.querySelector("#accounts-message"),
   csvFile: document.querySelector("#csv-file"),
   importPreview: document.querySelector("#import-preview"),
   previewAccounts: document.querySelector("#preview-accounts"),
@@ -102,6 +105,77 @@ function makeCell(text, className) {
   return cell;
 }
 
+function accountCard(account) {
+  const form = document.createElement("form");
+  form.className = "account-card";
+  const heading = document.createElement("div");
+  heading.className = "account-card-heading";
+  const identity = document.createElement("div");
+  const source = document.createElement("span");
+  source.className = "account-source";
+  source.textContent = account.source;
+  const key = document.createElement("small");
+  key.textContent = account.external_key;
+  identity.append(source, key);
+  const status = document.createElement("span");
+  status.className = `account-state ${account.is_active ? "active" : "archived"}`;
+  status.textContent = account.is_active ? "Active" : "Archived";
+  heading.append(identity, status);
+
+  const label = document.createElement("label");
+  label.textContent = "Display name";
+  const input = document.createElement("input");
+  input.name = "display_name";
+  input.maxLength = 80;
+  input.required = true;
+  input.value = account.display_name;
+
+  const actions = document.createElement("div");
+  actions.className = "account-actions";
+  const save = document.createElement("button");
+  save.className = "compact primary";
+  save.type = "submit";
+  save.textContent = "Save name";
+  const toggle = document.createElement("button");
+  toggle.className = "compact secondary";
+  toggle.type = "button";
+  toggle.textContent = account.is_active ? "Archive" : "Reactivate";
+  toggle.addEventListener("click", () => updateAccount(account.id, { is_active: !account.is_active }));
+  actions.append(save, toggle);
+  form.append(heading, label, input, actions);
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    updateAccount(account.id, { display_name: input.value.trim() });
+  });
+  return form;
+}
+
+async function loadAccounts() {
+  if (!client || !currentUser) return;
+  clearMessage(elements.accountsMessage);
+  const { data, error } = await client.from("bank_accounts")
+    .select("id,source,external_key,display_name,currency,is_active,created_at,updated_at")
+    .order("is_active", { ascending: false }).order("created_at", { ascending: true });
+  if (error) {
+    elements.accountsList.replaceChildren();
+    return showMessage(elements.accountsMessage, error.message);
+  }
+  elements.accountsList.replaceChildren(...data.map(accountCard));
+  if (!data.length) showMessage(elements.accountsMessage, "No accounts detected yet. Import a bank CSV below to create them.", "success");
+}
+
+async function updateAccount(accountId, changes) {
+  if (!client || !currentUser) return;
+  if ("display_name" in changes && !changes.display_name) return showMessage(elements.accountsMessage, "Account name cannot be empty.");
+  clearMessage(elements.accountsMessage);
+  const { error } = await client.from("bank_accounts")
+    .update({ ...changes, updated_at: new Date().toISOString() }).eq("id", accountId);
+  if (error) return showMessage(elements.accountsMessage, error.message);
+  showMessage(elements.accountsMessage, "Account updated.", "success");
+  await loadAccounts();
+  await loadTransactions();
+}
+
 async function loadTransactions() {
   if (!client || !currentUser) return;
   clearMessage(elements.transactionsMessage);
@@ -149,7 +223,8 @@ function showFeature(feature) {
   elements.transactionsMenuButton.classList.toggle("active", !showImport);
   elements.importMenuButton.setAttribute("aria-current", showImport ? "page" : "false");
   elements.transactionsMenuButton.setAttribute("aria-current", showImport ? "false" : "page");
-  if (!showImport) loadTransactions();
+  if (showImport) loadAccounts();
+  else loadTransactions();
 }
 
 function renderSession(session) {
@@ -246,6 +321,7 @@ async function importTransactions() {
     "success"
   );
   await loadTransactions();
+  await loadAccounts();
 }
 
 elements.loginTab.addEventListener("click", () => setMode("login"));
@@ -254,6 +330,7 @@ elements.authForm.addEventListener("submit", handleSubmit);
 elements.resetButton.addEventListener("click", resetPassword);
 elements.importMenuButton.addEventListener("click", () => showFeature("import"));
 elements.transactionsMenuButton.addEventListener("click", () => showFeature("transactions"));
+elements.refreshAccounts.addEventListener("click", loadAccounts);
 elements.csvFile.addEventListener("change", handleFileSelection);
 elements.importButton.addEventListener("click", importTransactions);
 elements.refreshTransactions.addEventListener("click", loadTransactions);

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="PyBudget authentication and bank transaction import">
   <title>PyBudget</title>
-  <link rel="stylesheet" href="styles.css?v=4">
+  <link rel="stylesheet" href="styles.css?v=5">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 </head>
 <body>
@@ -58,12 +58,22 @@
             <strong id="user-email"></strong>
           </div>
           <nav class="app-menu" aria-label="PyBudget sections">
-            <button id="import-menu-button" class="menu-button active" type="button">Import</button>
+            <button id="import-menu-button" class="menu-button active" type="button">Setup</button>
             <button id="transactions-menu-button" class="menu-button" type="button">All transactions</button>
           </nav>
         </section>
 
-        <section id="import-view" class="card feature-view">
+        <section id="import-view" class="setup-stack feature-view">
+          <section class="card">
+            <div class="section-heading">
+              <div><p class="eyebrow green">Accounts</p><h2>Detected bank accounts</h2></div>
+              <button id="refresh-accounts" class="compact secondary" type="button">Refresh</button>
+            </div>
+            <p class="muted">Accounts are created automatically when they are found in an import. You can rename or archive them here.</p>
+            <p id="accounts-message" class="notice" role="status" aria-live="polite" hidden></p>
+            <div id="accounts-list" class="accounts-list"></div>
+          </section>
+          <section class="card">
           <p class="eyebrow green">Import</p>
           <h2>Bank transactions</h2>
           <p class="muted">Select a Comdirect CSV. The file is parsed in your browser; only normalized transactions are sent to your private database.</p>
@@ -79,6 +89,7 @@
           </div>
           <button id="import-button" class="primary" type="button" disabled>Import transactions</button>
           <p id="import-message" class="notice" role="status" aria-live="polite" hidden></p>
+          </section>
         </section>
 
         <section id="transactions-view" class="card transactions-card feature-view" hidden>
@@ -116,8 +127,8 @@
     </section>
   </main>
 
-  <script src="config.js?v=4"></script>
-  <script src="importer.js?v=4"></script>
-  <script src="app.js?v=4"></script>
+  <script src="config.js?v=5"></script>
+  <script src="importer.js?v=5"></script>
+  <script src="app.js?v=5"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -296,3 +296,22 @@ body.signed-in .logout-menu-button { display: none; }
   }
   body.signed-in .app-menu { grid-template-columns: 1fr 1fr; }
 }
+
+
+/* Account management */
+.setup-stack { display: grid; gap: 18px; width: 100%; }
+.accounts-list { display: grid; gap: 12px; margin-top: 18px; }
+.account-card { padding: 16px; border: 1px solid var(--line); border-radius: 13px; background: white; }
+.account-card-heading, .account-actions { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.account-card-heading small { display: block; max-width: 520px; margin-top: 4px; color: var(--muted); overflow-wrap: anywhere; }
+.account-source { font-size: .72rem; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; color: var(--green); }
+.account-state { padding: 4px 8px; border-radius: 999px; font-size: .72rem; font-weight: 750; }
+.account-state.active { color: var(--success); background: #e7f2e9; }
+.account-state.archived { color: var(--muted); background: #ecebe5; }
+.account-actions { justify-content: flex-start; margin-top: 12px; }
+.account-actions .primary { width: auto; margin: 0; }
+@media (max-width: 560px) {
+  .account-card-heading { align-items: flex-start; }
+  .account-actions { display: grid; grid-template-columns: 1fr 1fr; }
+  .account-actions button { width: 100%; }
+}

--- a/supabase/transaction_import.sql
+++ b/supabase/transaction_import.sql
@@ -93,6 +93,12 @@ drop policy if exists "Users read own bank accounts" on public.bank_accounts;
 create policy "Users read own bank accounts" on public.bank_accounts
   for select to authenticated using ((select auth.uid()) = user_id);
 
+drop policy if exists "Users update own bank accounts" on public.bank_accounts;
+create policy "Users update own bank accounts" on public.bank_accounts
+  for update to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
 drop policy if exists "Users read own import batches" on public.import_batches;
 create policy "Users read own import batches" on public.import_batches
   for select to authenticated using ((select auth.uid()) = user_id);
@@ -110,6 +116,7 @@ revoke all on public.import_batches from anon, authenticated;
 revoke all on public.transactions from anon, authenticated;
 revoke all on public.transaction_observations from anon, authenticated;
 grant select on public.bank_accounts to authenticated;
+grant update (display_name, is_active, updated_at) on public.bank_accounts to authenticated;
 grant select on public.import_batches to authenticated;
 grant select on public.transactions to authenticated;
 grant select on public.transaction_observations to authenticated;
@@ -199,7 +206,6 @@ begin
     )
     on conflict (user_id, source, external_key)
     do update set
-      display_name = excluded.display_name,
       updated_at = now()
     returning id into v_account_id;
 


### PR DESCRIPTION
## What changed

- renames Import to Setup
- lists automatically detected bank accounts
- allows users to rename, archive, and reactivate their own accounts
- preserves custom display names during later imports
- adds restricted column-level update grants and owner-only RLS update policy

## Release safety

The release branch was created from current `main`, so production keeps its production Supabase configuration. The development key is not included.